### PR TITLE
ssh support

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -5,6 +5,10 @@
 export PATH="$PATH:$PWD/scripts"
 export PATH="$PATH:$PWD/.bin"
 . .env
-if [[ -e .env.local  ]]; then
+if [[ -e .env.local ]]; then
   . .env.local
+fi
+
+if [[ -e .env.ssh && -n "$SSH_CLIENT" ]]; then
+  . .env.ssh
 fi

--- a/.envrc
+++ b/.envrc
@@ -8,7 +8,3 @@ export PATH="$PATH:$PWD/.bin"
 if [[ -e .env.local ]]; then
   . .env.local
 fi
-
-if [[ -e .env.ssh && -n "$SSH_CLIENT" ]]; then
-  . .env.ssh
-fi

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@
 build
 .xwin-cache
 .bin
-.env.local
+.env.*

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+  "recommendations": [
+    "mkhl.shfmt",
+    "ms-vscode-remote.remote-wsl",
+    "fill-labs.dependi",
+    "tamasfe.even-better-toml",
+    "rust-lang.rust-analyzer",
+    "timonwong.shellcheck"
+  ]
+}

--- a/scripts/cargo-wsl
+++ b/scripts/cargo-wsl
@@ -38,23 +38,24 @@ shopt -s globstar
 PKG_NAME="${PKG_NAME:-"bevy_game"}"
 BIN_NAME="${BIN_NAME:-"bevy_game"}"
 TARGET_DIR="${TARGET_DIR:-"target/x86_64-pc-windows-msvc/debug"}"
-TEMP="$(wslpath -au "$(pwsh.exe -c "echo \$env:TEMP")")"
-TEMP="$(echo "$TEMP" | tr -d '\r\n')"
-HOSTPATH="${HOSTPATH:-$TEMP/$PKG_NAME}"
 if [ -n "$CARGO_CMD" ]; then
   NORUN="true"
   NOSYNC="true"
 fi
 CARGO_CMD="${CARGO_CMD:-"build"}"
 
-SSH_PORT=${SSH_PORT:-$(echo "$SSH_CONNECTION" | cut -d ' ' -f 2)}
-SSH_IP=${SSH_IP:-$(echo "$SSH_CONNECTION" | cut -d ' ' -f 1)}
-SSH_USER=${SSH_USER:-$(whoami)}
-SSH_PATH="C:/Users/$SSH_USER/$PKG_NAME"
-SSH_DEST="scp://$SSH_USER@$SSH_IP:$SSH_PORT/$SSH_PATH"
 if [ -n "$SSH_CONNECTION" ]; then
+  SSH_PORT=${SSH_PORT:-$(echo "$SSH_CONNECTION" | cut -d ' ' -f 2)}
+  SSH_IP=${SSH_IP:-$(echo "$SSH_CONNECTION" | cut -d ' ' -f 1)}
+  SSH_USER=${SSH_USER:-$(whoami)}
+  SSH_PATH=${SSH_PATH:-"C:/Users/$SSH_USER/$PKG_NAME"}
+  SSH_DEST="scp://$SSH_USER@$SSH_IP:$SSH_PORT/$SSH_PATH"
   echo "SSH CLIENT CONNECTED."
   echo "DESTINATION: $SSH_DEST"
+else
+  TEMP="$(wslpath -au "$(pwsh.exe -c "echo \$env:TEMP")")"
+  TEMP="$(echo "$TEMP" | tr -d '\r\n')"
+  HOSTPATH="${HOSTPATH:-$TEMP/$PKG_NAME}"
 fi
 
 # Config from .env
@@ -86,8 +87,9 @@ if [ -z "$NOSYNC" ]; then
     echo "$START" >"$TARGET_DIR/start.ps1"
     # rsync -avP -e "ssh -p $SSH_PORT" --no-r "$TARGET_DIR"/* "$SSH_DEST"
     # rsync -avP -e "ssh -p $SSH_PORT" "assets"/* "$SSH_DEST"
-    # DYLIBS=$(echo $(find $TARGET_DIR -name "*.dll"))
-    scp -r "$TARGET_DIR/$BIN_NAME.exe" $DYLIBS "$TARGET_DIR/start.ps1" .env .env.local assets/ "$SSH_DEST"
+    zip -r "$TARGET_DIR/$BIN_NAME.zip" "$TARGET_DIR/$BIN_NAME.exe" "$TARGET_DIR/start.ps1" .env .env.local assets/
+    scp -r "$TARGET_DIR/$BIN_NAME.zip" "$SSH_DEST"
+    if [ -n "$SSH_EXTRA_COMMAND" ]; then bash -c "$SSH_EXTRA_COMMAND"; fi
   else
     rsync -avP --no-r "$TARGET_DIR"/* "$HOSTPATH"
     rsync -avP "assets"/* "$HOSTPATH/assets"

--- a/scripts/cargo-wsl
+++ b/scripts/cargo-wsl
@@ -1,6 +1,6 @@
 #!/bin/bash
 if [ "$2" = "-h" ] || [ "$2" = "--help" ]; then
-  cat <<EOF 
+  cat <<EOF
 cargo wsl [-h --help] <ARGS>
 This script builds and runs the game assuming you are running in a wsl environment.
 System dependencies: xwin, rsync.
@@ -30,29 +30,38 @@ PKG_NAME='tools' BIN_NAME='terrain-editor' cargo wsl
 # Run windbg without building.
 NOBUILD=true NOSYNC=true WINDBG=true cargo wsl
 EOF
-  exit 0;
-fi;
+  exit 0
+fi
 
 shopt -s globstar
 . .env
 PKG_NAME="${PKG_NAME:-"bevy_game"}"
 BIN_NAME="${BIN_NAME:-"bevy_game"}"
 TARGET_DIR="${TARGET_DIR:-"target/x86_64-pc-windows-msvc/debug"}"
-TEMP="$(wslpath -au "$(pwsh.exe -c "echo \$env:TEMP")")" 
+TEMP="$(wslpath -au "$(pwsh.exe -c "echo \$env:TEMP")")"
 TEMP="$(echo "$TEMP" | tr -d '\r\n')"
-HOSTPATH="${HOSTPATH:-$TEMP/$PKG_NAME}" 
+HOSTPATH="${HOSTPATH:-$TEMP/$PKG_NAME}"
 if [ -n "$CARGO_CMD" ]; then
   NORUN="true"
   NOSYNC="true"
 fi
 CARGO_CMD="${CARGO_CMD:-"build"}"
 
+SSH_PORT=${SSH_PORT:-$(echo "$SSH_CONNECTION" | cut -d ' ' -f 2)}
+SSH_IP=${SSH_IP:-$(echo "$SSH_CONNECTION" | cut -d ' ' -f 1)}
+SSH_USER=${SSH_USER:-$(whoami)}
+SSH_PATH="C:/Users/$SSH_USER/$PKG_NAME"
+SSH_DEST="scp://$SSH_USER@$SSH_IP:$SSH_PORT/$SSH_PATH"
+if [ -n "$SSH_CONNECTION" ]; then
+  echo "SSH CLIENT CONNECTED."
+  echo "DESTINATION: $SSH_DEST"
+fi
+
 # Config from .env
 # includes RUSTFLAGS and LINKER
 ARGS="${@:2}"
 if [ -z "$NOBUILD" ]; then
-  CMD="cargo $CARGO_CMD\
-    -F 'debug'\
+  CMD="cargo $CARGO_CMD    -F 'debug'\
     -F 'inspector'\
     -p '$PKG_NAME'\
     --bin '$BIN_NAME'\
@@ -68,12 +77,24 @@ if [ -z "$NOBUILD" ]; then
 fi
 
 if [ -z "$NOSYNC" ]; then
-  rsync -avP --no-r "$TARGET_DIR"/* "$HOSTPATH"
-  rsync -avP "assets"/* "$HOSTPATH/assets"
+  if [ -n "$SSH_CONNECTION" ]; then
+    START="\
+  Start-Process -Wait -Environment @{
+  RUST_LOG='$RUST_LOG'
+  DEBUG_LEVEL='$DEBUG_LEVEL'
+} -FilePath '$SSH_PATH/$BIN_NAME.exe'"
+    echo "$START" >"$TARGET_DIR/start.ps1"
+    # rsync -avP -e "ssh -p $SSH_PORT" --no-r "$TARGET_DIR"/* "$SSH_DEST"
+    # rsync -avP -e "ssh -p $SSH_PORT" "assets"/* "$SSH_DEST"
+    # DYLIBS=$(echo $(find $TARGET_DIR -name "*.dll"))
+    scp -r "$TARGET_DIR/$BIN_NAME.exe" $DYLIBS "$TARGET_DIR/start.ps1" .env .env.local assets/ "$SSH_DEST"
+  else
+    rsync -avP --no-r "$TARGET_DIR"/* "$HOSTPATH"
+    rsync -avP "assets"/* "$HOSTPATH/assets"
+  fi
 fi
 
-
-if [ -z "$NORUN" ]; then
+if [ -z "$NORUN" ] && [ -z "$SSH_CONNECTION" ]; then
   HOST_EXE="$(wslpath -aw "$HOSTPATH/$BIN_NAME.exe")"
   START="\
   Start-Process -NoNewWindow -Wait -Environment @{
@@ -84,12 +105,12 @@ if [ -z "$NORUN" ]; then
   REDIRECT="*> '$TTY'"
   if [ -n "$WINDBG" ]; then
     HOST_SRCPATH="$(
-      find ./crates ./src -name "*.rs" -type f -print0 \
-      | xargs -0 -I{} dirname {} \
-      | sort \
-      | uniq \
-      | xargs -I{} wslpath -aw {} \
-      | tr '\n' ';'
+      find ./crates ./src -name "*.rs" -type f -print0 |
+        xargs -0 -I{} dirname {} |
+        sort |
+        uniq |
+        xargs -I{} wslpath -aw {} |
+        tr '\n' ';'
     )"
     WINDBG_EXE=${WINDBG_EXE:-"windbgx.exe"}
     # todo: env vars?
@@ -106,4 +127,5 @@ if [ -z "$NORUN" ]; then
     echo "pwsh.exe -c \"$CMD\""
     pwsh.exe -c "$CMD"
   fi
+
 fi


### PR DESCRIPTION
Add support for SSH'ing into a build server and transferring the completed artifacts. 
![image](https://github.com/user-attachments/assets/58fc70a0-e646-46c5-b7a5-6a26388fc643)
The above is an example of how this can work securely over a WAN. PC 1 opens an SSH connection to the build server through a secure proxy, in this case a Raspberry Pi. It's possible to set WSL up to [mirror network connections](https://learn.microsoft.com/en-us/windows/wsl/networking#mirrored-mode-networking) so you can SSH directly into the WSL2 instance. (This is assuming the WSL2 instance is running and the server is awake. It's not trivial to keep WSL2 running all the time, nor to keep Windows awake when an SSH connection is active on WSL2, so there are some extra steps I'm skipping over here.) The proxy forwards all the commands and the code editor on PC 1 can work as normal. When the build server runs `cargo wsl`, it detects an SSH connection through the `$SSH_CONNECTION` variable, zips up the build, and transfers it via `scp` to a server specified through environment variables. Once the transfer is complete, the script runs the `$SSH_EXTRA_COMMAND` if available, in this case pinging [a simple pub/sub websocket server](https://bun.sh/docs/api/websockets#pub-sub) on the proxy device. PC1 has a script which listens for that ping. Once it receives it, it downloads the build assets from the proxy server, unzips them, and runs them. (You could send the assets directly over the websocket connection, but this risks dropping packets.) If you have a good network connection, this can speed up builds tremendously. Of course, the tradeoff is between network latency and the time it takes to build locally. In my case, the build server is significantly faster than the laptop, making the whole process worthwhile.

For security reasons, I will not be publishing the source code used to set up the proxy server.